### PR TITLE
FarmingBox UI 에서 아이템이 사용되지 않는 오류 수정

### DIFF
--- a/Client/Assets/Scripts/Contoller/InventoryController_FB.cs
+++ b/Client/Assets/Scripts/Contoller/InventoryController_FB.cs
@@ -28,6 +28,8 @@ namespace Inventory
 		private Action OnOpened;
 		private Action OnClosed;
 
+        private GameObject character;
+
 		UIInventoryPage_FB _inventorypage_FB;
 		PlayerInput playerInput;
 
@@ -41,6 +43,8 @@ namespace Inventory
 
 			BtnCancel.onClick.AddListener(() => CloseInventoryUI());
 			BtnCancel.onClick.AddListener(() => OnClosed?.Invoke());
+
+            character = GameObject.FindWithTag("Pilot");
 		}
 
 		/// <summary>
@@ -128,6 +132,7 @@ namespace Inventory
 			if (inventoryItem.IsEmpty)
 				return;
 		}
+
 		private void DropItem(int itemIndex, int quantity)
 		{
 			inventoryData_merged.RemoveItem(itemIndex, quantity);
@@ -143,7 +148,7 @@ namespace Inventory
 			IItemAction itemAction = inventoryItem.item as IItemAction;
 			if (itemAction != null)
 			{
-				itemAction.PerformAction(gameObject);
+				itemAction.PerformAction(character);
 
 				if (inventoryData_merged.GetItemAt(itemIndex).IsEmpty)
 				{


### PR DESCRIPTION
# 변경 및 추가 내용
- 현재 선택한 아이템 종류에 대한 처리 요청 시, 적용 대상에 대한 정보를 보내지 않아서였음. 
Pilot 태그를 가진 GameObject 를 찾고, 이를 입력값으로 주어 해결함.

#  기타 공유 및 요청사항
- ...